### PR TITLE
サインイン状態を維持できるように変更

### DIFF
--- a/app/src/main/java/com/github/kitakkun/foos/MainActivity.kt
+++ b/app/src/main/java/com/github/kitakkun/foos/MainActivity.kt
@@ -3,16 +3,30 @@ package com.github.kitakkun.foos
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import com.github.kitakkun.foos.common.navigation.MainScreen
+import com.github.kitakkun.foos.common.navigation.SubScreen
 import com.github.kitakkun.foos.ui.screen.AppScreen
+import com.google.firebase.auth.FirebaseAuth
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    @Inject
+    lateinit var firebaseAuth: FirebaseAuth
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        val startDestination = when (firebaseAuth.currentUser) {
+            null -> SubScreen.Auth.route
+            else -> MainScreen.Home.route
+        }
+
         setContent {
-            AppScreen()
+            AppScreen(
+                startDestination = startDestination,
+            )
         }
     }
 }

--- a/app/src/main/java/com/github/kitakkun/foos/ui/screen/AppScreen.kt
+++ b/app/src/main/java/com/github/kitakkun/foos/ui/screen/AppScreen.kt
@@ -21,7 +21,9 @@ import com.google.accompanist.navigation.material.rememberBottomSheetNavigator
  */
 @OptIn(ExperimentalMaterialNavigationApi::class)
 @Composable
-fun AppScreen() {
+fun AppScreen(
+    startDestination: String,
+) {
 
     val bottomSheetNavigator = rememberBottomSheetNavigator()
     val navController = rememberNavController(bottomSheetNavigator)
@@ -49,7 +51,7 @@ fun AppScreen() {
                 backgroundColor = MaterialTheme.colors.background,
                 bottomBar = {
                     ScreenBottomNavBar(
-                        navController,
+                        navController = navController,
                         onClick = { screen -> screenViewModel.navigate(screen.route) }
                     )
                 }
@@ -57,6 +59,7 @@ fun AppScreen() {
                 ScreenNavHost(
                     navController = navController,
                     screenViewModel = screenViewModel,
+                    startDestination = startDestination,
                     innerPadding = innerPadding
                 )
             }

--- a/common/src/main/java/com/github/kitakkun/foos/common/navigation/MainScreen.kt
+++ b/common/src/main/java/com/github/kitakkun/foos/common/navigation/MainScreen.kt
@@ -14,7 +14,11 @@ sealed class MainScreen(
 ) {
 
     companion object {
-        val screens = listOf(Home, Map, Reaction, Setting)
+        // need by lazy to avoid null pointer exception
+        // references:
+        // - https://stackoverflow.com/questions/54940944/initializing-companion-object-after-inner-objects/55010004
+        // - https://youtrack.jetbrains.com/issue/KT-8970/Object-is-uninitialized-null-when-accessed-from-static-context-ex.-companion-object-with-initialization-loop
+        val screens by lazy { listOf(Home, Map, Reaction, Setting) }
     }
 
     object Home : MainScreen(


### PR DESCRIPTION
タイトルの通り。
サインイン状態を保持できず、毎回サインイン画面にナビゲーションされていたのを修正します。

MainScreen.ktについて
新しく`by lazy`が付与されているのは、以下の条件でコールが発生するとNull Pointer Exceptionが発生するためです。

```kotlin
val home = MainScreen.Home
val screens = MainScreen.screens // Homeの箇所がnullになってしまう
screens[0].route // ｶﾞｯ（ぬるぽ）
```

https://youtrack.jetbrains.com/issue/KT-8970/Object-is-uninitialized-null-when-accessed-from-static-context-ex.-companion-object-with-initialization-loop

こちらでレポートされている内容です。バグではなく仕様のようです。

