### PR TITLE
ダークテーマの軽微な修正

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -2,7 +2,7 @@
 <resources>
 
     <style name="Theme.FooS" parent="android:Theme.Material.Light.NoActionBar">
-        <item name="android:statusBarColor">@color/white</item>
-        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:statusBarColor">@color/black</item>
+        <item name="android:windowLightStatusBar">false</item>
     </style>
 </resources>

--- a/customview/src/main/java/com/github/kitakkun/foos/customview/theme/Theme.kt
+++ b/customview/src/main/java/com/github/kitakkun/foos/customview/theme/Theme.kt
@@ -5,11 +5,13 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 
 private val DarkColorPalette = darkColors(
-    primary = Purple200,
-    primaryVariant = Purple700,
-    secondary = Teal200
+    primary = BrownLight,
+    primaryVariant = Brown,
+    secondary = YellowLight,
+    onPrimary = Color.White,
 )
 
 private val LightColorPalette = lightColors(

--- a/post/src/main/java/com/github/kitakkun/foos/post/timeline/HomeScreen.kt
+++ b/post/src/main/java/com/github/kitakkun/foos/post/timeline/HomeScreen.kt
@@ -1,5 +1,6 @@
 package com.github.kitakkun.foos.post.timeline
 
+import android.content.res.Configuration
 import android.net.Uri
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -121,6 +122,7 @@ private fun HomeUI(
 }
 
 @Preview
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun HomeUIPreview() = PreviewContainer {
     HomeUI(

--- a/user/src/main/java/com/github/kitakkun/foos/user/auth/signin/SignInScreen.kt
+++ b/user/src/main/java/com/github/kitakkun/foos/user/auth/signin/SignInScreen.kt
@@ -1,5 +1,6 @@
 package com.github.kitakkun.foos.user.auth.signin
 
+import android.content.res.Configuration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -63,9 +64,12 @@ fun SignInUI(
 ) {
     val signUpText = stringResource(id = R.string.sign_up)
     val haveAccountText = stringResource(id = R.string.dont_have_account)
+    val haveAccountTextColor = MaterialTheme.colors.onBackground
     val signUpNavigateText = remember {
         buildAnnotatedString {
-            append(haveAccountText)
+            withStyle(style = SpanStyle(color = haveAccountTextColor)) {
+                append(haveAccountText)
+            }
             append(" ")
             // make SignUp text clickable by using annotation.
             pushStringAnnotation(tag = "SignUp", annotation = signUpText)
@@ -119,6 +123,7 @@ fun SignInUI(
 }
 
 @Preview
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun SignInScreenPreview() = PreviewContainer {
     SignInUI(

--- a/user/src/main/java/com/github/kitakkun/foos/user/auth/signup/SignUpScreen.kt
+++ b/user/src/main/java/com/github/kitakkun/foos/user/auth/signup/SignUpScreen.kt
@@ -1,5 +1,6 @@
 package com.github.kitakkun.foos.user.auth.signup
 
+import android.content.res.Configuration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -63,9 +64,12 @@ fun SignUpUI(
 ) {
     val signInText = stringResource(id = R.string.sign_in)
     val haveAccountText = stringResource(id = R.string.already_have_account)
+    val haveAccountTextColor = MaterialTheme.colors.onBackground
     val signUpNavigateText = remember {
         buildAnnotatedString {
-            append(haveAccountText)
+            withStyle(style = SpanStyle(color = haveAccountTextColor)) {
+                append(haveAccountText)
+            }
             append(" ")
             // make SignUp text clickable by using annotation.
             pushStringAnnotation(tag = "SignIn", annotation = signInText)
@@ -119,6 +123,7 @@ fun SignUpUI(
 }
 
 @Preview
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun SignUpUIPreview() = PreviewContainer {
     SignUpUI(


### PR DESCRIPTION
- デフォルトの紫ベースになっていたのを修正（茶色ベースに）
- 認証画面（ SignIn/SignUp ）で黒文字が見えなくなる問題を修正
- ステータスバーの色がダークテーマ時とライトテーマ時で切り替わるように（白黒）