### PR TITLE
Fix hanging up after re-authentication

### DIFF
--- a/user/src/main/java/com/github/kitakkun/foos/user/auth/signup/SignUpViewModel.kt
+++ b/user/src/main/java/com/github/kitakkun/foos/user/auth/signup/SignUpViewModel.kt
@@ -59,6 +59,7 @@ class SignUpViewModel @Inject constructor(
                 }
             } catch (e: Throwable) {
                 Log.e(TAG, "signUp: ", e)
+                _uiState.value = _uiState.value.copy(isLoading = false)
                 withContext(Dispatchers.Main) {
                     onComplete(false)
                 }


### PR DESCRIPTION
close #85 

## 概要
ログアウト後に再認証すると画面が固まり遷移しなくなる不具合を修正します。

## 解決した方法
UsersRepositoryImpl内で、Firestoreにユーザーデータを作成する箇所があるのだが、事前にget().await()してみたら、バグが起こらなくなった。

1回目の認証時には問題が起こらないので、なんでやろのお気持ち。
まあ直ったのでヨシッ！